### PR TITLE
fix: configured export dir in gitattributes, duplicated license/readm…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore

--- a/addons/toastparty/LICENSE
+++ b/addons/toastparty/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Francisco Pereira Alvarado (gammafp)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/addons/toastparty/README.md
+++ b/addons/toastparty/README.md
@@ -1,0 +1,36 @@
+# Toast Party
+
+Have fun with this marvelous plugin for generating small toast notifications.
+
+Toast Party is a versatile plugin for Godot that allows you to easily create toast-style notifications in your games and applications. Add an extra layer of interactivity and visual feedback to your Godot projects with ease. Bring your messages to life with Toast Party!
+
+Plugin created by Francisco Pereira Alvarado ([gammafp](https://twitter.com/gammafp)).
+
+Please follow me on my social networks to follow my jobs: [LINKTREE](https://linktr.ee/gammafp)
+
+![Main Screen](no-copy-imgs/example.gif)
+
+
+## Installation:
+1. Clone this repository into addons folder.
+2. Enabled ToastParty, go to: Porject > Project Settings > Plugins
+
+![Drag Racing](no-copy-imgs/toast-party-install.png)
+
+## Use:
+ToastParty is an autoload singleton and should be used as follows:
+
+```python 
+> ToastParty.show({
+    "text": "🥑Some Text🥑",       # Text (emojis can be admit)
+    "bgcolor": Color(0, 0, 0, 0.7), # Background Color
+    "color": Color(1, 1, 1, 1),     # Text Color
+    "gravity": "top",               # top or bottom
+    "direction": "right",           # left or center or right
+})
+```
+
+## License
+Copyright (c) 2023 Francisco Pereira Alvarado (gammafp)
+
+Unless otherwise specified, files in this repository are licensed under the MIT license. See [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
I wanted to test out your addon and couldn't so I fixed the folder structure and gitattributes file for you as per godot documented guidelines on posting to the asset library:
https://docs.godotengine.org/en/stable/community/asset_library/submitting_to_assetlib.html#recommendations

If you accept and update your asset library submission, people will actually be able to use your addon now.
